### PR TITLE
Update Dockerfile-base-debian

### DIFF
--- a/Dockerfile-base-debian
+++ b/Dockerfile-base-debian
@@ -13,7 +13,7 @@ RUN apt-get update && \
     chown root:root /etc/apt/trusted.gpg.d/microsoft.asc.gpg && \
     chown root:root /etc/apt/sources.list.d/microsoft-prod.list && \
     apt-get update && \
-    apt-get install -yq aspnetcore-runtime-2.1 && \
+    apt-get install -yq aspnetcore-runtime-2.2 && \
     apt-get clean -y && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
.net Core 2.2 (for multi-tenancy support) does not run in the container without these changes.